### PR TITLE
メッセージ送信時の画面遷移を廃止

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,33 @@
 
 <body>
 
-	<form action="sub.php" method="post">
+	<form id="sendMessage">
 		<p>名前</p>
 		<input type="text" name="name">
 		<p>コメント</p>
 		<textarea name="message"></textarea>
-		<input type="submit" value="送信">
-		<br><br>
 	</form>
+	<button onClick="sendMessage()">送信</button>
+	<script>
+		function sendMessage(params) {
+			const formElm = document.getElementById("sendMessage");
+			const name = formElm.name.value;
+			const message = formElm.message.value;
+			
+			$.ajax({
+				type: "POST",
+				url: "sub.php",
+				data: {"name" : name, 
+					   "message" : message}
+			}).done(function(){
+			}).fail(function (XMLHttpRequest, textStatus, errorThrown) {
+				console.log(XMLHttpRequest.status);
+				console.log(textStatus);
+				console.log(errorThrown.message);
+			});
+		}
+	</script>
+	<br><br>
 
 </body>
 

--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
 			const formElm = document.getElementById("sendMessage");
 			const name = formElm.name.value;
 			const message = formElm.message.value;
+			formElm.name.value = '';
+			formElm.message.value = '';
 			
 			$.ajax({
 				type: "POST",

--- a/sub.php
+++ b/sub.php
@@ -1,40 +1,22 @@
-<!DOCTYPE html>
-<html lang="ja">
+<?php
+require './vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__)->load();
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBNAME'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>掲示板</title>
-</head>
+if (!empty($_POST["name"]) && !empty($_POST["message"])) {
+    $name = htmlspecialchars($_POST["name"], ENT_QUOTES);
+    $message = htmlspecialchars($_POST["message"], ENT_QUOTES);
 
-<body>
+    $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
 
-    <?php
-    require './vendor/autoload.php';
-    Dotenv\Dotenv::createImmutable(__DIR__)->load();
-    $host = $_ENV['HOST'];
-    $DBname = $_ENV['DBNAME'];
-    $user = $_ENV['USER'];
-    $passwd = $_ENV['PASSWD'];
+    $db->query("INSERT INTO tb1(no, name, message, time)
+            VALUES(NULL, '$name', '$message', NOW())");
 
-    if (!empty($_POST["name"]) && !empty($_POST["message"])) {
-        $name = htmlspecialchars($_POST["name"], ENT_QUOTES);
-        $message = htmlspecialchars($_POST["message"], ENT_QUOTES);
+} else {
+}
 
-        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-
-        $db->query("INSERT INTO tb1(no, name, message, time)
-             VALUES(NULL, '$name', '$message', NOW())");
-
-        print "<h1>コメント送信完了しました</h1>";
-        print "<p><a href=index.html>掲示板へ戻る</a></p>";
-    } else {
-        print "<h1>※フォームが入力されていません</h1>";
-        print "<p><a href=index.html>掲示板へ戻る</a></p>";
-    }
-
-    ?>
-
-</body>
-
-</html>
+exit;
+?>


### PR DESCRIPTION
## 変更の概要

メッセージ送信時（送信ボタンクリック時）に画面遷移をしないようにした．

## なぜこの変更をするのか

メッセージ送信時に一々画面遷移，及び掲示板画面へ戻るためにリンククリックするのが不要だと感じたから．

## やったこと

- [x] メッセージ送信時に画面遷移をなくした
- [x] メッセージ送信後に入力欄を空にした

## 変更内容

- `index.html`ファイル内の`<form action>`をjavascriptの実行に変更．
- 上記のjsコードでJQueryを使用してサーバへの送信，及びDBへの登録
- 上記のjsコードで入力欄を空にした
- `sub.php`ファイル内のPHP部分以外を削除．（画面遷移後の画面を削除）

## 課題

- ボタンクリック時の処理を`index.html`ファイル内で行ったため，ファイル分けできていない

## 備考

- そろそろ各ファイルのフォルダ分けをした方が良いかもしれない
- 上記の様ないわゆる暗黙の了解的なものを知らないため，勉強する必要あり． 