### PR TITLE
掲示板名を動的に付ける

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
 		echo "<tr><th>NO.</th><td>掲示板一覧</td></tr>";
 		$count = 1;
 		foreach ($data as $value) {
-			echo "<tr><th>$count</th><td><a href=\"keiziban/index.php?table%5B%5D='$value'\">$value</a></td></tr>";
+			echo "<tr><th>$count</th><td><a href=\"keiziban/index.php?table%5B%5D=$value\">$value</a></td></tr>";
 			$count++;
 		}
 		echo "</table>";

--- a/keiziban/index.php
+++ b/keiziban/index.php
@@ -7,25 +7,27 @@
 	<!-- jqueryを読み込み -->
 	<script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
 	<meta charset="utf-8" />
-	<title>掲示板-tb1</title>
-</head>
 
-<body>
-	
 	<?php
 		require dirname(__FILE__).'/../vendor/autoload.php';
         Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
-		$data = $_GET['table'];
+		$table = $_GET['table'][0];
 	?>
 
 	<script type="text/javascript">
-		const table = <?= $data[0]; ?>; 
+		const table = <?= "'" . $table . "'"; ?>; 
 		const homeURL = <?= "\"".$_ENV['HOMEURL']."\"" ?>;
 	</script>
 
+	<title>掲示板-<?= $table; ?></title>
+</head>
+
+<body>
+	<h1><?= $table; ?></h1>
+
 	<a href="../index.php">戻る</a>
 
-	<br><br>
+	<br>
 
 	<form id="sendMessage">
 		<p>名前</p>
@@ -56,11 +58,9 @@
 			});
 		}
 	</script>
-	<br><br>
 
-</body>
+	<br><br><br>
 
-<body>
 	<div id="displayArea">
 		<!-- jsファイルを読み込み -->
 		<script type="text/javascript" src="js/display.js"></script>


### PR DESCRIPTION
## 変更の概要

- `keiziban/index.php`のタイトルを動的に変更した

### 関連

- #3 の備考


## なぜこの変更をするのか

以前から放置され続けていたから

## やったこと

- [x] 掲示板ページのタイトルへ掲示板名を表示
- [x] 掲示板ページの上部に掲示板名を表示

## 変更内容

- 各掲示板名を`$_GET`にて取得・各掲示板のタイトルへ反映
- 同手順にて取得・掲示板ページへの上部に掲示板名を表示
- タイトルにシングルクォーテーションが付かない様にGETで渡すデータを調整