### PR TITLE
DBへユーザ名・メールアドレス・パスワード（ハッシュ値）を保存

### DIFF
--- a/test/index.php
+++ b/test/index.php
@@ -5,9 +5,8 @@ if (isset($_SESSION['id'])) {//ログインしているとき
     $msg = 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん';
     $link = '<a href="logout.php">ログアウト</a>';
 } else {//ログインしていない時
-    $msg = 'ログインしていません';
-    $link = '<a href="login.php">ログイン</a>';
+    echo '<br>ログインしていません<br>';
+    echo '<br><a href="login_form.php">ログイン</a><br>';
+    echo '<br><a href="signup.php">新規登録</a><br>';
 }
 ?>
-<h1><?php echo $msg; ?></h1>
-<?php echo $link; ?>

--- a/test/register.php
+++ b/test/register.php
@@ -1,38 +1,29 @@
 <?php
-//フォームからの値をそれぞれ変数に代入
+require dirname(__FILE__).'/../vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
 $mail = $_POST['mail'];
 $pass = password_hash($_POST['pass'], PASSWORD_DEFAULT);
-$dsn = "mysql:host=localhost; dbname=xxx; charset=utf8";
-$username = "xxx";
-$password = "xxx";
-try {
-    $dbh = new PDO($dsn, $username, $password);
-} catch (PDOException $e) {
-    $msg = $e->getMessage();
-}
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBACCOUNT'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
 
-//フォームに入力されたmailがすでに登録されていないかチェック
-$sql = "SELECT * FROM users WHERE mail = :mail";
-$stmt = $dbh->prepare($sql);
-$stmt->bindValue(':mail', $mail);
-$stmt->execute();
-$member = $stmt->fetch();
-if ($member['mail'] === $mail) {
-    $msg = '同じメールアドレスが存在します。';
-    $link = '<a href="signup.php">戻る</a>';
+$db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+$n = $db->query("SELECT * FROM user WHERE mail = $mail");
+
+$i = $n->fetch();
+if (!empty($i['mail'])) {
+    echo "同じメールアドレスが存在します。<br>";
 } else {
-    //登録されていなければinsert 
-    $sql = "INSERT INTO users(name, mail, pass) VALUES (:name, :mail, :pass)";
-    $stmt = $dbh->prepare($sql);
-    $stmt->bindValue(':name', $name);
-    $stmt->bindValue(':mail', $mail);
-    $stmt->bindValue(':pass', $pass);
-    $stmt->execute();
-    $msg = '会員登録が完了しました';
-    $link = '<a href="login.php">ログインページ</a>';
+    try {
+        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        echo "<br>登録できました．<br>";
+    } catch (Exception $e) {
+        echo "<br>登録できませんでした．<br>";
+    }
 }
-?>
 
-<h1><?php echo $msg; ?></h1><!--メッセージの出力-->
-<?php echo $link; ?>
+echo "<a href='signup.php'>戻る</a>";
+?>

--- a/test/signup.php
+++ b/test/signup.php
@@ -1,5 +1,5 @@
 <h1>新規会員登録</h1>
-<form action="register.php" method="post">//処理を行う宛先を指定
+<form action="register.php" method="post">
 <div>
     <label>名前：<label>
     <input type="text" name="name" required>


### PR DESCRIPTION
## 変更の概要

アカウント情報を保存するデータベースを作成し，そこにデータを保存する

### 関連

- #11 

## やったこと

- 環境に合わせ，ファイルのリンク等のパスを調整
- DBへの接続・クエリ実行のやり方を統一
- アカウント情報保存用のDBを設定

## 変更内容

- `test/index.html`のからログイン・新規登録画面へ移動できる様に
- .envファイルを使用してDB接続情報を読み込む
- DBへの接続・クエリ実行を以前から使用しているものへと変更，及び本環境への調整
- アカウント情報保存用のDBを設定

## 課題

- 現在のハッシュ化では安全性が低いこと