### PR TITLE
ログイン機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Forum-B
 
-参考・ベースとさせていただいたwebサイトは[こちら](https://denkenmusic.com/php%e3%81%a8mariadbmysql%e3%81%ae%e5%9f%ba%e7%a4%8e%e2%91%a4%e3%80%8c%e6%8e%b2%e7%a4%ba%e6%9d%bf%e3%82%92%e5%ae%8c%e6%88%90%e3%81%95%e3%81%9b%e3%81%a6%e3%81%bf%e3%82%88%e3%81%86%e3%80%8d2%e3%83%9a/)です．
+参考・ベースとさせていただいたwebサイト
+
+[PHPとMariaDB(MySQL)の基礎⑤「掲示板を完成させてみよう」2ページのPHPファイルで掲示板の作成方法](https://denkenmusic.com/php%e3%81%a8mariadbmysql%e3%81%ae%e5%9f%ba%e7%a4%8e%e2%91%a4%e3%80%8c%e6%8e%b2%e7%a4%ba%e6%9d%bf%e3%82%92%e5%ae%8c%e6%88%90%e3%81%95%e3%81%9b%e3%81%a6%e3%81%bf%e3%82%88%e3%81%86%e3%80%8d2%e3%83%9a/)です．
+[PHPログイン機能](https://qiita.com/ryo-futebol/items/5fb635199acc2fcbd3ff)

--- a/index.php
+++ b/index.php
@@ -8,6 +8,8 @@
 
 <body>
 
+	<a href=test/index.php>ログインデモ</a>
+
 	<?php
 		require './vendor/autoload.php';
 		Dotenv\Dotenv::createImmutable(__DIR__)->load();

--- a/test/index.php
+++ b/test/index.php
@@ -1,0 +1,13 @@
+<?php
+session_start();
+$username = $_SESSION['name'];
+if (isset($_SESSION['id'])) {//ログインしているとき
+    $msg = 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん';
+    $link = '<a href="logout.php">ログアウト</a>';
+} else {//ログインしていない時
+    $msg = 'ログインしていません';
+    $link = '<a href="login.php">ログイン</a>';
+}
+?>
+<h1><?php echo $msg; ?></h1>
+<?php echo $link; ?>

--- a/test/index.php
+++ b/test/index.php
@@ -5,9 +5,8 @@ if (isset($_SESSION['id'])) {//ログインしているとき
     $msg = 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん';
     $link = '<a href="logout.php">ログアウト</a>';
 } else {//ログインしていない時
-    $msg = 'ログインしていません';
-    $link = '<a href="login.php">ログイン</a>';
+    echo '<br>ログインしていません<br>';
+    echo '<br><a href="login_form.php">ログイン</a><br>';
+    echo '<br><a href="signup.php">新規登録</a><br>';
 }
 ?>
-<h1><?php echo $msg; ?></h1>
-<?php echo $link; ?>

--- a/test/index.php
+++ b/test/index.php
@@ -2,8 +2,8 @@
 session_start();
 $username = $_SESSION['name'];
 if (isset($_SESSION['id'])) {//ログインしているとき
-    $msg = 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん';
-    $link = '<a href="logout.php">ログアウト</a>';
+    echo 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん' . "<br><br>";
+    echo '<a href="logout.php">ログアウト</a>';
 } else {//ログインしていない時
     echo '<br>ログインしていません<br>';
     echo '<br><a href="login_form.php">ログイン</a><br>';

--- a/test/login.php
+++ b/test/login.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+$mail = $_POST['mail'];
+$dsn = "mysql:host=localhost; dbname=xxx; charset=utf8";
+$username = "xxx";
+$password = "xxx";
+try {
+    $dbh = new PDO($dsn, $username, $password);
+} catch (PDOException $e) {
+    $msg = $e->getMessage();
+}
+
+$sql = "SELECT * FROM users WHERE mail = :mail";
+$stmt = $dbh->prepare($sql);
+$stmt->bindValue(':mail', $mail);
+$stmt->execute();
+$member = $stmt->fetch();
+//指定したハッシュがパスワードにマッチしているかチェック
+if (password_verify($_POST['pass'], $member['pass'])) {
+    //DBのユーザー情報をセッションに保存
+    $_SESSION['id'] = $member['id'];
+    $_SESSION['name'] = $member['name'];
+    $msg = 'ログインしました。';
+    $link = '<a href="index.php">ホーム</a>';
+} else {
+    $msg = 'メールアドレスもしくはパスワードが間違っています。';
+    $link = '<a href="login.php">戻る</a>';
+}
+?>
+
+<h1><?php echo $msg; ?></h1>
+<?php echo $link; ?>

--- a/test/login.php
+++ b/test/login.php
@@ -21,6 +21,19 @@ if (password_verify($_POST['pass'], $member['pass'])) {
     echo '<a href="index.php">ホーム</a>';
 } else {
     echo 'メールアドレスもしくはパスワードが間違っています。';
+    echo "<h1>ログインページ（再）</h1>";
+    echo "<form action='login.php' method='post'>";
+    echo "<div>";
+    echo "<label>ユーザID：<label>";
+    echo "<input type='text' name='name' required>";
+    echo "</div>";
+    echo "<div>";
+    echo "<label>パスワード：<label>";
+    echo "<input type='password' name='pass' required>";
+    echo "</div>";
+    echo "<input type='submit' value='ログイン'>";
+    echo "</form>";
+
     echo '<a href="login.php">戻る</a>';
 }
 ?>

--- a/test/login.php
+++ b/test/login.php
@@ -1,32 +1,26 @@
 <?php
 session_start();
-$mail = $_POST['mail'];
-$dsn = "mysql:host=localhost; dbname=xxx; charset=utf8";
-$username = "xxx";
-$password = "xxx";
-try {
-    $dbh = new PDO($dsn, $username, $password);
-} catch (PDOException $e) {
-    $msg = $e->getMessage();
-}
+require dirname(__FILE__).'/../vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
+$name = $_POST['name'];
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBACCOUNT'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
 
-$sql = "SELECT * FROM users WHERE mail = :mail";
-$stmt = $dbh->prepare($sql);
-$stmt->bindValue(':mail', $mail);
-$stmt->execute();
-$member = $stmt->fetch();
+$db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+$n = $db->query("SELECT * FROM user WHERE name = '$name'");
+
+$member = $n->fetch();
 //指定したハッシュがパスワードにマッチしているかチェック
 if (password_verify($_POST['pass'], $member['pass'])) {
     //DBのユーザー情報をセッションに保存
     $_SESSION['id'] = $member['id'];
     $_SESSION['name'] = $member['name'];
-    $msg = 'ログインしました。';
-    $link = '<a href="index.php">ホーム</a>';
+    echo 'ログインしました。';
+    echo '<a href="index.php">ホーム</a>';
 } else {
-    $msg = 'メールアドレスもしくはパスワードが間違っています。';
-    $link = '<a href="login.php">戻る</a>';
+    echo 'メールアドレスもしくはパスワードが間違っています。';
+    echo '<a href="login.php">戻る</a>';
 }
 ?>
-
-<h1><?php echo $msg; ?></h1>
-<?php echo $link; ?>

--- a/test/login_form.php
+++ b/test/login_form.php
@@ -1,8 +1,8 @@
 <h1>ログインページ</h1>
 <form action="login.php" method="post">
 <div>
-    <label>メールアドレス：<label>
-    <input type="text" name="mail" required>
+    <label>ユーザID：<label>
+    <input type="text" name="name" required>
 </div>
 <div>
     <label>パスワード：<label>

--- a/test/login_form.php
+++ b/test/login_form.php
@@ -1,0 +1,12 @@
+<h1>ログインページ</h1>
+<form action="login.php" method="post">
+<div>
+    <label>メールアドレス：<label>
+    <input type="text" name="mail" required>
+</div>
+<div>
+    <label>パスワード：<label>
+    <input type="password" name="pass" required>
+</div>
+<input type="submit" value="ログイン">
+</form>

--- a/test/logout.php
+++ b/test/logout.php
@@ -1,0 +1,8 @@
+<?php
+session_start();
+$_SESSION = array();//セッションの中身をすべて削除
+session_destroy();//セッションを破壊
+?>
+
+<p>ログアウトしました。</p>
+<a href="login.php">ログインへ</a>

--- a/test/mail.php
+++ b/test/mail.php
@@ -1,12 +1,29 @@
 <?php
 session_start();
+require dirname(__FILE__).'/../vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBACCOUNT'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
+$name = $_SESSION['name'];
+$mail = $_SESSION['mail'];
+$pass = $_SESSION['pass'];
 $rand = $_SESSION['code'];
 $otp = $_POST['code'];
 
 if ($rand == $otp) {
-	unset($_SESSION['code']);
+	$_SESSION = array();
+	$_POST = array();
 
-	echo "登録しました．<br>";
+    try {
+        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        echo "<br>登録できました．<br>";		
+    } catch (Exception $e) {
+        echo "<br>登録できませんでした．<br>";
+    }
+
 } else {
 	echo "コードが間違っています<br><br>";
     echo "<h1>メール承認（再）</h1>";

--- a/test/mail.php
+++ b/test/mail.php
@@ -1,0 +1,8 @@
+<?php
+session_start();
+$rand = $_SESSION['code'];
+unset($_SESSION['code']);
+
+echo $rand;
+
+?>

--- a/test/mail.php
+++ b/test/mail.php
@@ -34,4 +34,6 @@ if ($rand == $otp) {
     echo "</form>";
 }
 
+echo "<a href='index.php'>ホームへ</a>;";
+
 ?>

--- a/test/mail.php
+++ b/test/mail.php
@@ -6,6 +6,7 @@ $host = $_ENV['HOST'];
 $DBname = $_ENV['DBACCOUNT'];
 $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
+$id = $_COOKIE['PHPSESSID'];
 $name = $_SESSION['name'];
 $mail = $_SESSION['mail'];
 $pass = $_SESSION['pass'];
@@ -18,7 +19,7 @@ if ($rand == $otp) {
 
     try {
         $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        $db->query("INSERT INTO user(no, id, name, mail, pass) VALUES(NULL, '$id', '$name', '$mail', '$pass')");
         echo "<br>登録できました．<br>";		
     } catch (Exception $e) {
         echo "<br>登録できませんでした．<br>";

--- a/test/mail.php
+++ b/test/mail.php
@@ -1,8 +1,20 @@
 <?php
 session_start();
 $rand = $_SESSION['code'];
-unset($_SESSION['code']);
+$otp = $_POST['code'];
 
-echo $rand;
+if ($rand == $otp) {
+	unset($_SESSION['code']);
+
+	echo "登録しました．<br>";
+} else {
+	echo "コードが間違っています<br><br>";
+    echo "<h1>メール承認（再）</h1>";
+    echo "<form action='mail.php' method='post'>";
+    echo "<label>コード</label><br>";
+    echo "<input type='text' name='code' required>";
+    echo "<input type='submit' value='確認'>";
+    echo "</form>";
+}
 
 ?>

--- a/test/mail.php
+++ b/test/mail.php
@@ -34,6 +34,6 @@ if ($rand == $otp) {
     echo "</form>";
 }
 
-echo "<a href='index.php'>ホームへ</a>;";
+echo "<a href='index.php'>ホームへ</a>";
 
 ?>

--- a/test/register.php
+++ b/test/register.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require dirname(__FILE__).'/../vendor/autoload.php';
 Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
@@ -16,14 +17,23 @@ $i = $n->fetch();
 if (!empty($i['mail']) || !empty($i['name'])) {
     echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
-    try {
-        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
-        echo "<br>登録できました．<br>";
-    } catch (Exception $e) {
-        echo "<br>登録できませんでした．<br>";
+    $rand = mt_rand(100000, 999999);
+
+    mb_language("Japanese");
+    mb_internal_encoding("UTF-8");
+
+    $to = $mail;
+    $title = 'HxS掲示板・新規登録';
+    $message = 'コード : '.$rand;
+    $headers = "From: hoge21119@gmail.com";
+
+    if (mb_send_mail($to, $title, $message, $headers)) {
+        echo "メール送信成功です";
+    } else {
+        echo "メール送信失敗です";
     }
 }
 
+echo "<br><br>";
 echo "<a href='signup.php'>戻る</a>";
 ?>

--- a/test/register.php
+++ b/test/register.php
@@ -1,38 +1,29 @@
 <?php
-//フォームからの値をそれぞれ変数に代入
+require dirname(__FILE__).'/../vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
 $mail = $_POST['mail'];
 $pass = password_hash($_POST['pass'], PASSWORD_DEFAULT);
-$dsn = "mysql:host=localhost; dbname=xxx; charset=utf8";
-$username = "xxx";
-$password = "xxx";
-try {
-    $dbh = new PDO($dsn, $username, $password);
-} catch (PDOException $e) {
-    $msg = $e->getMessage();
-}
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBACCOUNT'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
 
-//フォームに入力されたmailがすでに登録されていないかチェック
-$sql = "SELECT * FROM users WHERE mail = :mail";
-$stmt = $dbh->prepare($sql);
-$stmt->bindValue(':mail', $mail);
-$stmt->execute();
-$member = $stmt->fetch();
-if ($member['mail'] === $mail) {
-    $msg = '同じメールアドレスが存在します。';
-    $link = '<a href="signup.php">戻る</a>';
+$db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+$n = $db->query("SELECT * FROM user WHERE mail = $mail");
+
+$i = $n->fetch();
+if (!empty($i['mail'])) {
+    echo "同じメールアドレスが存在します。<br>";
 } else {
-    //登録されていなければinsert 
-    $sql = "INSERT INTO users(name, mail, pass) VALUES (:name, :mail, :pass)";
-    $stmt = $dbh->prepare($sql);
-    $stmt->bindValue(':name', $name);
-    $stmt->bindValue(':mail', $mail);
-    $stmt->bindValue(':pass', $pass);
-    $stmt->execute();
-    $msg = '会員登録が完了しました';
-    $link = '<a href="login.php">ログインページ</a>';
+    try {
+        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        echo "<br>登録できました．<br>";
+    } catch (Exception $e) {
+        echo "<br>登録できませんでした．<br>";
+    }
 }
-?>
 
-<h1><?php echo $msg; ?></h1><!--メッセージの出力-->
-<?php echo $link; ?>
+echo "<a href='signup.php'>戻る</a>";
+?>

--- a/test/register.php
+++ b/test/register.php
@@ -1,0 +1,38 @@
+<?php
+//フォームからの値をそれぞれ変数に代入
+$name = $_POST['name'];
+$mail = $_POST['mail'];
+$pass = password_hash($_POST['pass'], PASSWORD_DEFAULT);
+$dsn = "mysql:host=localhost; dbname=xxx; charset=utf8";
+$username = "xxx";
+$password = "xxx";
+try {
+    $dbh = new PDO($dsn, $username, $password);
+} catch (PDOException $e) {
+    $msg = $e->getMessage();
+}
+
+//フォームに入力されたmailがすでに登録されていないかチェック
+$sql = "SELECT * FROM users WHERE mail = :mail";
+$stmt = $dbh->prepare($sql);
+$stmt->bindValue(':mail', $mail);
+$stmt->execute();
+$member = $stmt->fetch();
+if ($member['mail'] === $mail) {
+    $msg = '同じメールアドレスが存在します。';
+    $link = '<a href="signup.php">戻る</a>';
+} else {
+    //登録されていなければinsert 
+    $sql = "INSERT INTO users(name, mail, pass) VALUES (:name, :mail, :pass)";
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindValue(':name', $name);
+    $stmt->bindValue(':mail', $mail);
+    $stmt->bindValue(':pass', $pass);
+    $stmt->execute();
+    $msg = '会員登録が完了しました';
+    $link = '<a href="login.php">ログインページ</a>';
+}
+?>
+
+<h1><?php echo $msg; ?></h1><!--メッセージの出力-->
+<?php echo $link; ?>

--- a/test/register.php
+++ b/test/register.php
@@ -3,7 +3,7 @@ session_start();
 require dirname(__FILE__).'/../vendor/autoload.php';
 Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
-$mail = $_POST['mail'];
+$mail = $_POST['mail']."@st.oit.ac.jp";
 $pass = password_hash($_POST['pass'], PASSWORD_DEFAULT);
 $host = $_ENV['HOST'];
 $DBname = $_ENV['DBACCOUNT'];
@@ -26,7 +26,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
 
-    $to = $mail."@st.oit.ac.jp";
+    $to = $mail;
     $title = 'HxS掲示板・新規登録';
     $message = 'コード : '.$rand;
     $headers = "From: hoge21119@gmail.com";

--- a/test/register.php
+++ b/test/register.php
@@ -18,6 +18,10 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
     $rand = mt_rand(100000, 999999);
+    $_SESSION['name'] = $name;
+    $_SESSION['mail'] = $mail;
+    $_SESSION['pass'] = $pass;
+    $_SESSION['code'] = $rand;
 
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
@@ -32,6 +36,14 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     } else {
         echo "メール送信失敗です";
     }
+
+    echo "<h1>メール承認</h1>";
+    echo "<form action='mail.php' method='post'>";
+    echo "入力されたメールアドレスあてに承認コードを送信しました．<br><br>";
+    echo "<label>コード</label><br>";
+    echo "<input type='text' name='code' required>";
+    echo "<input type='submit' value='確認'>";
+    echo "</form>";
 }
 
 echo "<br><br>";

--- a/test/register.php
+++ b/test/register.php
@@ -39,7 +39,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
 
     echo "<h1>メール承認</h1>";
     echo "<form action='mail.php' method='post'>";
-    echo "入力されたメールアドレスあてに承認コードを送信しました．<br><br>";
+    echo "入力されたメールアドレス宛てに承認コードを送信しました．<br><br>";
     echo "<label>コード</label><br>";
     echo "<input type='text' name='code' required>";
     echo "<input type='submit' value='確認'>";

--- a/test/register.php
+++ b/test/register.php
@@ -11,7 +11,7 @@ $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
 
 $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-$n = $db->query("SELECT * FROM user WHERE 'mail' = '$mail' OR 'name' = '$name'");
+$n = $db->query("SELECT * FROM user WHERE mail = '$mail' OR name = '$name'");
 
 $i = $n->fetch();
 if (!empty($i['mail']) || !empty($i['name'])) {

--- a/test/register.php
+++ b/test/register.php
@@ -26,7 +26,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
 
-    $to = $mail;
+    $to = $mail."@st.oit.ac.jp";
     $title = 'HxS掲示板・新規登録';
     $message = 'コード : '.$rand;
     $headers = "From: hoge21119@gmail.com";

--- a/test/register.php
+++ b/test/register.php
@@ -10,11 +10,11 @@ $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
 
 $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-$n = $db->query("SELECT * FROM user WHERE mail = $mail");
+$n = $db->query("SELECT * FROM user WHERE 'mail' = '$mail' OR 'name' = '$name'");
 
 $i = $n->fetch();
-if (!empty($i['mail'])) {
-    echo "同じメールアドレスが存在します。<br>";
+if (!empty($i['mail']) || !empty($i['name'])) {
+    echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
     try {
         $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);

--- a/test/signup.php
+++ b/test/signup.php
@@ -1,16 +1,18 @@
 <h1>新規会員登録</h1>
 <form action="register.php" method="post">
 <div>
-    <label>名前：<label>
+    <label>ユーザID：<label>
     <input type="text" name="name" required>
 </div>
 <div>
     <label>メールアドレス：<label>
     <input type="text" name="mail" required>
+    @st.oit.ac.jp
 </div>
 <div>
     <label>パスワード：<label>
     <input type="password" name="pass" required>
+    ※パスワードは大学アカウントのものとは別にしてください．全力は尽くしますが，安全とは言えません
 </div>
 <input type="submit" value="新規登録">
 </form>

--- a/test/signup.php
+++ b/test/signup.php
@@ -1,5 +1,5 @@
 <h1>新規会員登録</h1>
-<form action="register.php" method="post">//処理を行う宛先を指定
+<form action="register.php" method="post">
 <div>
     <label>名前：<label>
     <input type="text" name="name" required>

--- a/test/signup.php
+++ b/test/signup.php
@@ -1,0 +1,17 @@
+<h1>新規会員登録</h1>
+<form action="register.php" method="post">//処理を行う宛先を指定
+<div>
+    <label>名前：<label>
+    <input type="text" name="name" required>
+</div>
+<div>
+    <label>メールアドレス：<label>
+    <input type="text" name="mail" required>
+</div>
+<div>
+    <label>パスワード：<label>
+    <input type="password" name="pass" required>
+</div>
+<input type="submit" value="新規登録">
+</form>
+<p>すでに登録済みの方は<a href="login.php">こちら</a></p>


### PR DESCRIPTION
## 変更の概要

掲示板にログイン機能（デモ）を実装する

### 関連

- #10 
- #12 
- #13 
- #14 
- #15 
- #16 
- #17 

## やったこと

- 新規登録
  - [x] `ユーザID`, `メールアドレス`, `パスワード`(OIT垢とは別物) アカウント情報をDBに追加（テスト）
  - [x] ハッシュ値生成にソルト・ストレッチングを利用する（password_hash()関数で十分みたいです. [参考](https://webukatu.com/wordpress/blog/26116/)）
  - [x] `ユーザID`, `メールアドレス` に一意性を持たせる
  - [x] 新規登録時，入力されたメールアドレスにワンタイムパスワード（OTP）を送信する
  - [x] メールアドレスは確実に自分の大学垢アドレスを使用してもらう
  - [x] 確認メール（OTP）の承認ができ次第，アカウント情報をDBに追加

- ログイン
  - [x] `ユーザID`, `パスワード`によりDBのアカウント情報と照合
  - [x] ログイン後はホーム画面ではじかれないようにする

- ホーム画面
  - [x] ログインできていなければ正規の画面を表示しない

- ログアウト
  - [x] ログアウト後はホーム画面に戻れないようにする

## なぜこの変更をするのか

- ログイン機能による様々な機能を実装を目指す
- **基本的** には匿名性を確保しつつ，**緊急時** にはメールアドレスから特定できる様にする
  （普段はユーザIDだけを表示するから匿名にはなるけども，**変なことは本当にしないでね**）

## やらないこと

デモとして開発するため，本pull request関連では掲示板への変更を無しとします

## 課題

- 最善は尽くすが，安全性は低い（セキュリティ）ものであることに注意してもらう
- 多数の入力を実装するが，SQLインジェクション対策等ができていない

## 備考

- 細かく分けると目標とする機能が多いので，`feature/login_demo`ブランチをベースとします
- ログイン機能関連のものは`feature/login_demo`からブランチを切って`feature/login_demo-<機能>`とします
- この方式に対して何かあればご連絡ください