### PR TITLE
ユーザIDとメールアドレスに一意性を持たせる

### DIFF
--- a/test/register.php
+++ b/test/register.php
@@ -10,11 +10,11 @@ $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
 
 $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-$n = $db->query("SELECT * FROM user WHERE mail = $mail");
+$n = $db->query("SELECT * FROM user WHERE 'mail' = '$mail' OR 'name' = '$name'");
 
 $i = $n->fetch();
-if (!empty($i['mail'])) {
-    echo "同じメールアドレスが存在します。<br>";
+if (!empty($i['mail']) || !empty($i['name'])) {
+    echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
     try {
         $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);


### PR DESCRIPTION
## 変更の概要

ユーザIDとメールアドレスの重複をなくす

### 関連

- #11 

## やったこと

- [x] 同じユーザIDまたは同じメールアドレスで新規登録をできないようにした

## 変更内容

- クエリ実行後の検証をメールアドレスにも適応させた
- 警告？表示に **同じユーザID** の箇所を追加

## 課題

重複はなくなるはずだが，DBのカラムにユニーク属性を付けられなかった．
ユニーク属性を付けようとするとエラーが発生するもよう