### PR TITLE
新規登録時，入力されたメールアドレスにワンタイムパスワード（OTP）を送信する

### DIFF
--- a/test/mail.php
+++ b/test/mail.php
@@ -1,0 +1,8 @@
+<?php
+session_start();
+$rand = $_SESSION['code'];
+unset($_SESSION['code']);
+
+echo $rand;
+
+?>

--- a/test/register.php
+++ b/test/register.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require dirname(__FILE__).'/../vendor/autoload.php';
 Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
@@ -16,14 +17,23 @@ $i = $n->fetch();
 if (!empty($i['mail']) || !empty($i['name'])) {
     echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
-    try {
-        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
-        echo "<br>登録できました．<br>";
-    } catch (Exception $e) {
-        echo "<br>登録できませんでした．<br>";
+    $rand = mt_rand(100000, 999999);
+
+    mb_language("Japanese");
+    mb_internal_encoding("UTF-8");
+
+    $to = $mail;
+    $title = 'HxS掲示板・新規登録';
+    $message = 'コード : '.$rand;
+    $headers = "From: hoge21119@gmail.com";
+
+    if (mb_send_mail($to, $title, $message, $headers)) {
+        echo "メール送信成功です";
+    } else {
+        echo "メール送信失敗です";
     }
 }
 
+echo "<br><br>";
 echo "<a href='signup.php'>戻る</a>";
 ?>

--- a/test/register.php
+++ b/test/register.php
@@ -18,6 +18,10 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     echo "同じメールアドレスまたは，同じユーザIDが存在します。<br>";
 } else {
     $rand = mt_rand(100000, 999999);
+    $_SESSION['name'] = $name;
+    $_SESSION['mail'] = $mail;
+    $_SESSION['pass'] = $pass;
+    $_SESSION['code'] = $rand;
 
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
@@ -32,6 +36,14 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     } else {
         echo "メール送信失敗です";
     }
+
+    echo "<h1>メール承認</h1>";
+    echo "<form action='mail.php' method='post'>";
+    echo "入力されたメールアドレスあてに承認コードを送信しました．<br><br>";
+    echo "<label>コード</label><br>";
+    echo "<input type='text' name='code' required>";
+    echo "<input type='submit' value='確認'>";
+    echo "</form>";
 }
 
 echo "<br><br>";


### PR DESCRIPTION
## 変更の概要

- 新規登録時に，入力されるメールアドレスにOTPを送信
- OPT入力欄の設置

### 関連

- #11 

## やったこと

- [x] 入力されたユーザID・メールアドレス・パスワードのDBへの保存処理を削除
- [x] OTPを生成し，入力されたメールアドレス宛にメールを送信
- [x] メール送信後，OTP入力欄を設置

## やらないこと

- メールアドレスの制限
- 送信されたOTPと入力されたOTPの検証

## 変更の概要

- 入力されたユーザID・メールアドレス・パスワードのDBへの保存処理を削除
- 同じメールアドレス・ユーザIDが存在しなければ，OTPを生成・メールの送信・OTP入力欄を設置
- ユーザ情報はセッションにて保存・ファイル間の受け渡しをする

## 備考

GETメソッドにてユーザ情報を受け渡すのはどうかと思い，セッションにて受け渡しをした．ただ，セッションをこのように使用するのは問題無いのか不明．