### PR TITLE
確認メールでの検証ができ次第，アカウント情報をDBに追加する

### DIFF
--- a/test/mail.php
+++ b/test/mail.php
@@ -1,12 +1,29 @@
 <?php
 session_start();
+require dirname(__FILE__).'/../vendor/autoload.php';
+Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
+$host = $_ENV['HOST'];
+$DBname = $_ENV['DBACCOUNT'];
+$user = $_ENV['USER'];
+$passwd = $_ENV['PASSWD'];
+$name = $_SESSION['name'];
+$mail = $_SESSION['mail'];
+$pass = $_SESSION['pass'];
 $rand = $_SESSION['code'];
 $otp = $_POST['code'];
 
 if ($rand == $otp) {
-	unset($_SESSION['code']);
+	$_SESSION = array();
+	$_POST = array();
 
-	echo "登録しました．<br>";
+    try {
+        $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
+        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        echo "<br>登録できました．<br>";		
+    } catch (Exception $e) {
+        echo "<br>登録できませんでした．<br>";
+    }
+
 } else {
 	echo "コードが間違っています<br><br>";
     echo "<h1>メール承認（再）</h1>";

--- a/test/mail.php
+++ b/test/mail.php
@@ -1,8 +1,20 @@
 <?php
 session_start();
 $rand = $_SESSION['code'];
-unset($_SESSION['code']);
+$otp = $_POST['code'];
 
-echo $rand;
+if ($rand == $otp) {
+	unset($_SESSION['code']);
+
+	echo "登録しました．<br>";
+} else {
+	echo "コードが間違っています<br><br>";
+    echo "<h1>メール承認（再）</h1>";
+    echo "<form action='mail.php' method='post'>";
+    echo "<label>コード</label><br>";
+    echo "<input type='text' name='code' required>";
+    echo "<input type='submit' value='確認'>";
+    echo "</form>";
+}
 
 ?>

--- a/test/register.php
+++ b/test/register.php
@@ -39,7 +39,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
 
     echo "<h1>メール承認</h1>";
     echo "<form action='mail.php' method='post'>";
-    echo "入力されたメールアドレスあてに承認コードを送信しました．<br><br>";
+    echo "入力されたメールアドレス宛てに承認コードを送信しました．<br><br>";
     echo "<label>コード</label><br>";
     echo "<input type='text' name='code' required>";
     echo "<input type='submit' value='確認'>";


### PR DESCRIPTION
## 変更の概要

入力された文字列（数字列）と，メールに送られた文字列が一致すれば，`ユーザID`, `メールアドレス`, `パスワード` をDBに保存する

### 関連

- #11 

## やったこと

- [x] メールに送信されたOTPと入力されたOTPの一致を確認
- [x] OTPの検証が確認され次第DBへアカウント情報を保存
- [x] `test/mail.php`ファイルでの再読込時に，再度DBに保存されるのを防止
- [x] OTP入力失敗時に再度の入力ができる様に

## 変更内容

- `test/register.php`ファイル内の出力メッセージを修正（42行：アドレスあてに -> アドレス宛に）
- OTPと入力された値が一致すればDBへアカウント情報を登録
- OTPの検証が確認できれば，$_SESSION, $_POSTの中身を削除
- OTP入力失敗時は$_SESSION, $_POSTの中身を削除せずに，再度`test/mail.php`ファイルへと遷移

## 課題

- ワンタイムパスワードに有効期限がないこと
- こちらの意図しない再読み込みがされた場合の処理が必要