### PR TITLE
登録メールアドレスを大学のものへと強制

### DIFF
--- a/test/mail.php
+++ b/test/mail.php
@@ -34,4 +34,6 @@ if ($rand == $otp) {
     echo "</form>";
 }
 
+echo "<a href='index.php'>ホームへ</a>;";
+
 ?>

--- a/test/mail.php
+++ b/test/mail.php
@@ -34,6 +34,6 @@ if ($rand == $otp) {
     echo "</form>";
 }
 
-echo "<a href='index.php'>ホームへ</a>;";
+echo "<a href='index.php'>ホームへ</a>";
 
 ?>

--- a/test/register.php
+++ b/test/register.php
@@ -3,7 +3,7 @@ session_start();
 require dirname(__FILE__).'/../vendor/autoload.php';
 Dotenv\Dotenv::createImmutable(__DIR__.'/..')->load();
 $name = $_POST['name'];
-$mail = $_POST['mail'];
+$mail = $_POST['mail']."@st.oit.ac.jp";
 $pass = password_hash($_POST['pass'], PASSWORD_DEFAULT);
 $host = $_ENV['HOST'];
 $DBname = $_ENV['DBACCOUNT'];
@@ -26,7 +26,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
 
-    $to = $mail."@st.oit.ac.jp";
+    $to = $mail;
     $title = 'HxS掲示板・新規登録';
     $message = 'コード : '.$rand;
     $headers = "From: hoge21119@gmail.com";

--- a/test/register.php
+++ b/test/register.php
@@ -11,7 +11,7 @@ $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
 
 $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-$n = $db->query("SELECT * FROM user WHERE 'mail' = '$mail' OR 'name' = '$name'");
+$n = $db->query("SELECT * FROM user WHERE mail = '$mail' OR name = '$name'");
 
 $i = $n->fetch();
 if (!empty($i['mail']) || !empty($i['name'])) {

--- a/test/register.php
+++ b/test/register.php
@@ -26,7 +26,7 @@ if (!empty($i['mail']) || !empty($i['name'])) {
     mb_language("Japanese");
     mb_internal_encoding("UTF-8");
 
-    $to = $mail;
+    $to = $mail."@st.oit.ac.jp";
     $title = 'HxS掲示板・新規登録';
     $message = 'コード : '.$rand;
     $headers = "From: hoge21119@gmail.com";

--- a/test/signup.php
+++ b/test/signup.php
@@ -1,16 +1,18 @@
 <h1>新規会員登録</h1>
 <form action="register.php" method="post">
 <div>
-    <label>名前：<label>
+    <label>ユーザID：<label>
     <input type="text" name="name" required>
 </div>
 <div>
     <label>メールアドレス：<label>
     <input type="text" name="mail" required>
+    @st.oit.ac.jp
 </div>
 <div>
     <label>パスワード：<label>
     <input type="password" name="pass" required>
+    ※パスワードは大学アカウントのものとは別にしてください．全力は尽くしますが，安全とは言えません
 </div>
 <input type="submit" value="新規登録">
 </form>


### PR DESCRIPTION
## 変更の概要

- アカウント情報として登録するメールアドレスを大学のものへと強制
- DBへの問い合わせを修正し，期待する動きをさせる

### 関連

- #11 

## やったこと

- [x] 入力されたメールアドレスに`@st.oit.ac.jp`を付けることで大学のアカウントへと強制
- [x] 入力欄にコメント・注意してほしいことを表示
- [x] DBへの問い合わせを期待通りに動くよう修正

## 変更内容

- 入力されたメールアドレスに`@st.oit.ac.jp`を付けて，`$mail`変数に格納
- `test/sigunup.php`で入力に対してコメント・注意を表示
- DBへの問い合わせのカラム部分のシングルクォーテーションを削除
- 新規登録後の画面にホーム画面へ移動するためのリンクを追加