### PR TITLE
ログイン状態ではホーム画面ではじかれない様に

### DIFF
--- a/test/index.php
+++ b/test/index.php
@@ -2,8 +2,8 @@
 session_start();
 $username = $_SESSION['name'];
 if (isset($_SESSION['id'])) {//ログインしているとき
-    $msg = 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん';
-    $link = '<a href="logout.php">ログアウト</a>';
+    echo 'こんにちは' . htmlspecialchars($username, \ENT_QUOTES, 'UTF-8') . 'さん' . "<br><br>";
+    echo '<a href="logout.php">ログアウト</a>';
 } else {//ログインしていない時
     echo '<br>ログインしていません<br>';
     echo '<br><a href="login_form.php">ログイン</a><br>';

--- a/test/mail.php
+++ b/test/mail.php
@@ -6,6 +6,7 @@ $host = $_ENV['HOST'];
 $DBname = $_ENV['DBACCOUNT'];
 $user = $_ENV['USER'];
 $passwd = $_ENV['PASSWD'];
+$id = $_COOKIE['PHPSESSID'];
 $name = $_SESSION['name'];
 $mail = $_SESSION['mail'];
 $pass = $_SESSION['pass'];
@@ -18,7 +19,7 @@ if ($rand == $otp) {
 
     try {
         $db = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
-        $db->query("INSERT INTO user(no, name, mail, pass) VALUES(NULL, '$name', '$mail', '$pass')");
+        $db->query("INSERT INTO user(no, id, name, mail, pass) VALUES(NULL, '$id', '$name', '$mail', '$pass')");
         echo "<br>登録できました．<br>";		
     } catch (Exception $e) {
         echo "<br>登録できませんでした．<br>";


### PR DESCRIPTION
## 変更の概要

ログイン状態ではホーム画面でユーザIDが表示され，そうでなければログイン・新規登録画面へのリンクを表示する

### 関連

- #11 

## やったこと

- [x] ログイン状態とそうでない場合でホーム画面の表示を変えた

## 変更内容

- DBに`id`のカラムを追加
- 新規登録時に`$_COOKIE['PHPSESSID']`をDBに`id`として登録

## 課題

- 現状では，変数`$_SESSION['id']`に何かしらが入っていればログイン状態となってしまう（大丈夫なのか不明）
- `id`が固定になってしまっている

## 備考

`id`が固定になっているため，セッションハイジャックの問題がある．しかし，そもそもセッションを正しく使用できているかが不明．
ログイン状態の確認のためにDBの`id`とセッションとして保持している`id`を照合した方がいいような気がする