### PR TITLE
特殊文字の変換後，元へ戻す

### DIFF
--- a/keiziban/php/Send_C.php
+++ b/keiziban/php/Send_C.php
@@ -26,8 +26,8 @@ class Send_C {
             try {
 		    	$pdo = new PDO("mysql:host=$this->host;dbname=$this->DBname", $this->user, $this->passwd);
 	    		$stmt = $pdo->prepare("INSERT INTO $this->table(no, name, message, time) VALUES(NULL, :name, :message, NOW())");
-                $stmt->bindValue(':name', $name);
-                $stmt->bindValue(':message', $message);
+                $stmt->bindValue(':name', htmlspecialchars_decode($name, ENT_QUOTES));
+                $stmt->bindValue(':message', htmlspecialchars_decode($message, ENT_QUOTES));
                 $stmt->execute();
             } catch (Exception $e) {
                 exit;

--- a/login_out/login.php
+++ b/login_out/login.php
@@ -11,7 +11,7 @@ $passwd = htmlspecialchars($_ENV['PASSWD'], ENT_QUOTES, 'UTF-8');
 try {
     $pdo = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
     $stmt = $pdo->prepare("SELECT * FROM user WHERE name = :name");
-    $stmt->bindValue(':name', $name);
+    $stmt->bindValue(':name', htmlspecialchars_decode($name, ENT_QUOTES));
     $stmt->execute();
 } catch (Exception $e) {
     exit;

--- a/login_out/mail.php
+++ b/login_out/mail.php
@@ -21,9 +21,9 @@ if ($rand == $otp) {
         $pdo = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
         $stmt = $pdo->prepare("INSERT INTO user(no, id, name, mail, pass) VALUES(NULL, :id, :name, :mail, :pass)");
         $stmt->bindValue(':id', $id);
-        $stmt->bindValue(':name', $name);
-        $stmt->bindValue(':mail', $mail);
-        $stmt->bindValue(':pass', $pass);
+        $stmt->bindValue(':name', htmlspecialchars_decode($name, ENT_QUOTES));
+        $stmt->bindValue(':mail', htmlspecialchars_decode($mail, ENT_QUOTES));
+        $stmt->bindValue(':pass', htmlspecialchars_decode($pass, ENT_QUOTES));
         $stmt->execute();
         echo "<br>登録できました．<br>";		
     } catch (Exception $e) {

--- a/login_out/register.php
+++ b/login_out/register.php
@@ -13,8 +13,8 @@ $passwd = htmlspecialchars($_ENV['PASSWD'], ENT_QUOTES, 'UTF-8');
 try {
     $pdo = new PDO("mysql:host=$host;dbname=$DBname", $user, $passwd);
     $stmt = $pdo->prepare("SELECT * FROM user WHERE mail = :mail OR name = :name");
-    $stmt->bindValue(':mail', $mail);
-    $stmt->bindValue(':name', $name);
+    $stmt->bindValue(':mail', htmlspecialchars_decode($mail, ENT_QUOTES));
+    $stmt->bindValue(':name', htmlspecialchars_decode($name, ENT_QUOTES));
     $stmt->execute();
 } catch (Exception $e) {
     exit;


### PR DESCRIPTION
## 変更の概要

攻撃対策として利用していた`htmlspecialchars()`による置換を元に戻してからDBに保存する

## なぜこの変更をするのか

DBに特殊文字が置換された状態で保存されると，掲示板に出力されるとき，置換されたまま出力されてしまい，意味不明な文字列が出力されてしまうのを直すため

## やったこと

- [x] DBに保存する直前に置換されていた特殊文字を元に戻す

## 変更内容

- `bindValue()`関数内では特殊文字が問題無いため，その関数内で置換されていた特殊文字を元に戻す
- 元に戻すのは`htmlspecialchars_decode()`を利用